### PR TITLE
rhine-common: Fix missing libcnefeatureconfig

### DIFF
--- a/rhine.mk
+++ b/rhine.mk
@@ -80,6 +80,10 @@ PRODUCT_PACKAGES += \
     libshim_camera \
     libstlport
 
+# Cpnnectivity
+PRODUCT_PACKAGES += \
+    libcnefeatureconfig
+
 # IPC Security Config
 PRODUCT_COPY_FILES += \
     $(COMMON_PATH)/rootdir/system/etc/sec_config:system/etc/sec_config


### PR DESCRIPTION
Change-Id: Ia71e4bb5f2345179590d371b629201633ca729ec